### PR TITLE
Feat rpscore

### DIFF
--- a/rpscore/config/job_conf.xml
+++ b/rpscore/config/job_conf.xml
@@ -1,0 +1,1 @@
+    <tool id="rpscore" destination="local" />

--- a/rpscore/config/tool_conf.xml
+++ b/rpscore/config/tool_conf.xml
@@ -1,0 +1,3 @@
+  <section id="sbc-pa" name="SynBioCAD Pathway Analysis">
+    <tool file="BRSynthTools/rpscore/wrap.xml" />
+  </section>

--- a/rpscore/wrap.xml
+++ b/rpscore/wrap.xml
@@ -1,0 +1,63 @@
+<tool id="rpscore" name="rpscore" version="5.4.1">
+    <description>Computes a global score for a heterologous pathway.</description>
+	<requirements>
+        <requirement type="package" version="5.4.1">rptools</requirement>
+    </requirements>
+    <command detect_errors="exit_code"><![CDATA[
+	    python -m rptools.rpscore '$pathway' '$output'
+        --no_of_rxns_thres '$no_of_rxns_thres'
+        --log '$adv.log_level'
+    ]]></command>
+    <inputs>
+		<param name="pathway" type="data" format="xml" label="Pathway (rpSBML)" />
+		<section name="adv" title="Advanced Options" expanded="false">
+            <param name="no_of_rxns_thres" type="integer" value="10" label="number of reactions above which a pathway is not scored" />
+			<param name="log_level"      type="select"  label="Log level">
+                <option value="debug"    type="text"                >debug</option>
+                <option value="info"     type="text"                >info</option>
+			    <option value="warning"  type="text"                >warning</option>
+			    <option value="error"    type="text" selected="true">error</option>
+			    <option value="critical" type="text"                >critical</option>
+            </param>
+		</section>
+    </inputs>
+    <outputs>
+        <data name="output" format="xml" label="${tool.name} - ${pathway.name}" />
+    </outputs>
+    <help><![CDATA[
+rpscore
+=====
+
+Computes a global score for a heterologous pathway. The score is calculated from a learning process based on reaction rules score, flux balance analysis and thermodynamics metrics, and the number of reactions in the pathway.
+
+
+Input
+-----
+
+Required:
+
+* **infile**\ : (string) Pathway file (rpSBML) with scores (rules, FBA, Thermo...)
+* **outfile**\ : (string) Path to write pathway file (rpSBML) with global score
+
+Advanced options:
+
+* **--no_of_rxns_thres**\ :(integer, default: 10) Number of reactions above which pathway are not scored (too long)
+* **--log**: (string, default=error) Set the log level, choices are 'debug', 'info', 'warning', 'error', 'critical'
+
+Version
+----------
+
+5.4.1
+
+Authors
+-------
+
+* **Jean-Loup Faulon**
+* **Joan Hérisson**
+
+Acknowledgments
+---------------
+
+* Thomas Duigou
+    ]]></help>
+</tool>

--- a/rpscore/wrap.xml
+++ b/rpscore/wrap.xml
@@ -5,7 +5,7 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 	    python -m rptools.rpscore '$pathway' '$output'
-        --no_of_rxns_thres '$no_of_rxns_thres'
+        --no_of_rxns_thres '$adv.no_of_rxns_thres'
         --log '$adv.log_level'
     ]]></command>
     <inputs>
@@ -26,7 +26,8 @@
     </outputs>
     <help><![CDATA[
 rpscore
-=====
+=========
+
 
 Computes a global score for a heterologous pathway. The score is calculated from a learning process based on reaction rules score, flux balance analysis and thermodynamics metrics, and the number of reactions in the pathway.
 


### PR DESCRIPTION
add rpscore wrapper (rptools v5.4.1)

command example:

` python -m rptools.rpscore '$pathway' '$output' --no_of_rxns_thres '$adv.no_of_rxns_thres' --log '$adv.log_level'`

